### PR TITLE
Add plot_uplift_by_percentile function to viz

### DIFF
--- a/sklift/metrics/__init__.py
+++ b/sklift/metrics/__init__.py
@@ -1,9 +1,9 @@
 from .metrics import (
-    uplift_curve, auuc, qini_curve, auqc, uplift_at_k, treatment_balance_curve,
+    uplift_curve, auuc, qini_curve, auqc, uplift_at_k, response_rate_by_percentile, treatment_balance_curve,
     uplift_auc_score, qini_auc_score
 )
 
 __all__ = [
-    uplift_curve, auuc, qini_curve, auqc, uplift_at_k, treatment_balance_curve,
+    uplift_curve, auuc, qini_curve, auqc, uplift_at_k, response_rate_by_percentile, treatment_balance_curve,
     uplift_auc_score, qini_auc_score
 ]

--- a/sklift/viz/__init__.py
+++ b/sklift/viz/__init__.py
@@ -1,3 +1,3 @@
-from .base import plot_uplift_preds, plot_uplift_qini_curves, plot_treatment_balance_curve
+from .base import plot_uplift_preds, plot_uplift_qini_curves, plot_uplift_by_percentile, plot_treatment_balance_curve
 
-__all__ = [plot_uplift_preds, plot_uplift_qini_curves, plot_treatment_balance_curve]
+__all__ = [plot_uplift_preds, plot_uplift_qini_curves, plot_uplift_by_percentile, plot_treatment_balance_curve]

--- a/sklift/viz/base.py
+++ b/sklift/viz/base.py
@@ -102,6 +102,82 @@ def plot_uplift_qini_curves(y_true, uplift, treatment, random=True, perfect=Fals
     return axes
 
 
+def plot_uplift_by_percentile(y_true, uplift, treatment, strategy, bins=10):
+    """Plot Uplift score at each percentile, 
+    Treatment response rate (target mean in the treatment group) 
+    and Control response rate (target mean in the control group) at each percentile.
+    
+    Args:
+        y_true (1d array-like): Correct (true) target values.
+        uplift (1d array-like): Predicted uplift, as returned by a model.
+        treatment (1d array-like): Treatment labels.
+        strategy (string, ['overall', 'by_group']): Determines the calculating strategy. Defaults to 'first'.
+            * ``'overall'``:
+                The first step is taking the first k observations of all test data ordered by uplift prediction
+                (overall both groups - control and treatment) and conversions in treatment and control groups
+                calculated only on them. Then the difference between these conversions is calculated.
+            * ``'by_group'``:
+                Separately calculates conversions in top k observations in each group (control and treatment)
+                sorted by uplift predictions. Then the difference between these conversions is calculated
+        bins (int): Determines the number of bins (and relative percentile) in the test data. 
+        
+    Returns:
+        Object that stores computed values.
+    """
+    
+    strategy_methods = ['overall', 'by_group']
+    
+    n_samples = len(y_true)
+    check_consistent_length(y_true, uplift, treatment)
+    
+    if strategy not in strategy_methods:
+        raise ValueError(f'Response rate supports only calculating methods in {strategy_methods},'
+                         f' got {strategy}.')
+    
+    if not isinstance(bins, int) or bins <= 0:
+        raise ValueError(f'bins should be positive integer.'
+                         f' Invalid value bins: {bins}')
+          
+    if bins >= n_samples:
+        raise ValueError(f'Number of bins = {bins} should be smaller than the length of y_true {n_samples}')
+    
+    if bins == 1:
+        warnings.warn(f'You will get the only one bin of {n_samples} samples'
+                      f' which is the length of y_true.' 
+                      f'\nPlease consider using uplift_at_k function instead',
+                      UserWarning)
+        
+    rspns_rate_trmnt, var_trmnt = response_rate_by_percentile(y_true, uplift,
+                                                              treatment, group='treatment',
+                                                              strategy=strategy, bins=bins)
+    
+    rspns_rate_ctrl, var_ctrl = response_rate_by_percentile(y_true, uplift,
+                                                            treatment, group='control',
+                                                            strategy=strategy, bins=bins)
+
+    uplift_score, uplift_variance = np.subtract(rspns_rate_trmnt, rspns_rate_ctrl), np.add(var_trmnt, var_ctrl)
+    
+    percentiles = [p * 100 / bins for p in range(1, bins + 1)]
+    
+    _, axes = plt.subplots(ncols=1, nrows=1, figsize=(8, 6))
+    
+    axes.errorbar(percentiles, uplift_score, yerr=np.sqrt(uplift_variance), 
+                  linewidth=2, color='red', label='uplift')
+    axes.errorbar(percentiles, rspns_rate_trmnt, yerr=np.sqrt(var_trmnt),
+                  linewidth=2, color='forestgreen', label='treatment\nresponse rate')
+    axes.errorbar(percentiles, rspns_rate_ctrl, yerr=np.sqrt(var_ctrl),
+                  linewidth=2, color='orange', label='control\nresponse rate')
+    axes.fill_between(percentiles, rspns_rate_ctrl, rspns_rate_trmnt, alpha=0.1, color='red')
+    
+    axes.set_xticks(percentiles)
+    axes.legend(loc='upper right')
+    axes.set_title('Uplift by percentile')
+    axes.set_xlabel('Percentile')
+    axes.set_ylabel('Uplift = treatment response rate - control response rate')
+    
+    return axes
+
+
 def plot_treatment_balance_curve(uplift, treatment, random=True, winsize=0.1):
     """Plot Treatment Balance curve.
 

--- a/sklift/viz/base.py
+++ b/sklift/viz/base.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from ..metrics import uplift_curve, auuc, qini_curve, auqc, treatment_balance_curve
+from ..metrics import uplift_curve, auuc, qini_curve, auqc, response_rate_by_percentile, treatment_balance_curve
 
 
 def plot_uplift_preds(trmnt_preds, ctrl_preds, log=False, bins=100):


### PR DESCRIPTION
Added two functions:

- response_rate_by_percentile function to metrics.py as a utility function that computes treatment and control response rates (scores) 
- Add plot_uplift_by_percentile to viz.py as a visualization of uplift at each precentile 
- plot_uplift_by_percentile uses response_rate_by_percentile