### PR TITLE
fix: remove reference to `treatment` variable

### DIFF
--- a/sklift/viz/base.py
+++ b/sklift/viz/base.py
@@ -28,7 +28,6 @@ def plot_uplift_preds(trmnt_preds, ctrl_preds, log=False, bins=100):
 
     # TODO: Add k as parameter: vertical line on plots
     check_consistent_length(trmnt_preds, ctrl_preds)
-    check_is_binary(treatment)
 
     if not isinstance(bins, int) or bins <= 0:
         raise ValueError(


### PR DESCRIPTION
---
name: "Pull request"
about: Make changes in scikit-uplift
---

## 📑 Description of the Change
Removed line `check_is_binary(treatment)` at the top of the function `plot_uplift_preds`
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

## Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected? 
- How did you verify that all changed functionality works as expected?

With the slightly changed function, visualization now works. Before, it produced an error because of the reference to the variable `treatment` that was not a function argument.

-->

## Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release history.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- Fix typo in TwoModels docstring.
- Add tutorial “Example of usage model from sklift.models in sklearn.pipeline”.
- Add plot_uplift_by_percentile.

-->

-Remove reference to `treatment` variable in `plot_uplift_preds` not included as function argument.

## Additional info

<!-- Add any other information or references. -->