### PR TITLE
Fix attribute call in fetch_x5 related to issue #89

### DIFF
--- a/sklift/datasets/datasets.py
+++ b/sklift/datasets/datasets.py
@@ -228,7 +228,7 @@ def fetch_x5(data_home=None, dest_subdir=None, download_if_missing=True):
                                  dest_filename=file_clients,
                                  download_if_missing=download_if_missing)
     clients = pd.read_csv(csv_clients_path)
-    clients_features = list(clients.column)
+    clients_features = list(clients.columns)
 
     url_purchases = 'https://timds.s3.eu-central-1.amazonaws.com/purchases.csv.gz'
     file_purchases = url_purchases.split('/')[-1]


### PR DESCRIPTION
---
name: "Pull request"
about: Make changes in scikit-uplift
---

## 📑 Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Fix attribute getter in function fetch_x5 from list(clients.column) to list(clients.columns) as the former call raises 
```python
AttributeError: 'DataFrame' object has no attribute 'column'
```

## Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?

-->

Run method 
```python
dataset.fetch_x5()
```

## Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release history.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- Fix typo in TwoModels docstring.
- Add tutorial “Example of usage model from sklift.models in sklearn.pipeline”.
- Add plot_uplift_by_percentile.

-->
- Fix typo in fetch_x5 function

## Additional info

<!-- Add any other information or references. -->
The most possible reason for this bug to occur is the missing test cases for x5 dataset