### PR TITLE
Add MIT license to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     classifiers=[
+        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
Added MIT license to classifiers in setup.py, which should add the proper license information to PyPI.

classifiers reference: https://pypi.org/classifiers/

Related issue:
https://github.com/maks-sh/scikit-uplift/issues/204