### PR TITLE
🔨  Remove usage of internal sklearn.utils api, replace with equivalent

### DIFF
--- a/sklift/utils/__init__.py
+++ b/sklift/utils/__init__.py
@@ -1,3 +1,3 @@
-from .utils import check_is_binary
+from .utils import check_is_binary, check_matplotlib_support
 
-__all__ = ['check_is_binary']
+__all__ = ['check_is_binary', 'check_matplotlib_support']

--- a/sklift/utils/utils.py
+++ b/sklift/utils/utils.py
@@ -11,3 +11,20 @@ def check_is_binary(array):
         raise ValueError(f"Input array is not binary. "
                          f"Array should contain only int or float binary values 0 (or 0.) and 1 (or 1.). "
                          f"Got values {np.unique(array)}.")
+
+
+def check_matplotlib_support(caller_name):
+    """Raise ImportError with detailed error message if mpl is not installed.
+    Plot utilities like any of the Display's plotting functions should lazily import
+    matplotlib and call this helper before any computation.
+    
+    Args:
+        caller_name (str): The name of the caller that requires matplotlib.
+    """
+    try:
+        import matplotlib  # noqa
+    except ImportError as e:
+        raise ImportError(
+            "{} requires matplotlib. You can install matplotlib with "
+            "`pip install matplotlib`".format(caller_name)
+        ) from e

--- a/sklift/viz/base.py
+++ b/sklift/viz/base.py
@@ -1,9 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.utils.validation import check_consistent_length
-from sklearn.utils import check_matplotlib_support
 
-from ..utils import check_is_binary
+from ..utils import check_is_binary, check_matplotlib_support
 from ..metrics import (
     uplift_curve, perfect_uplift_curve, uplift_auc_score,
     qini_curve, perfect_qini_curve, qini_auc_score,


### PR DESCRIPTION
---
name: "Pull request"
about: Make changes in scikit-uplift
---

## 📑 Description of the Change

I was trying to use this library with the modern version of sklearn in which they moved function `check_matplotlib_support` to the `_optional_dependencies` folder which looks like an internal one and thus can be moved again later. To properly solve this, I copied the implementation of this function to our utils.

## Verification Process

I tested a new version of library in my project and also checked it in existing tests.

## Release Notes

- Remove usage of internal `sklearn.utils.check_matplotlib_support` api and replace with equivalent
